### PR TITLE
Updates description of Axis3D[:frame, :linewidth]

### DIFF
--- a/src/Axis3D_attr_desc.jl
+++ b/src/Axis3D_attr_desc.jl
@@ -23,7 +23,7 @@ const Axis3D_attr_desc = Dict(
 # frame
 const Axis3D_attr_frame = Dict(
     :axiscolor => "Symbol or Colorant. Specifies the color of the axes. Can be a color symbol/string like :red, or a Colorant.",
-    :linewidth => "Number. Width of the axes lines.",
+    :linewidth => "Number. Width of the axes grid lines.",
     :linecolor => "Symbol or Colorant. Specifies the color of the grid lines. Can be a color symbol/string like :red, or a Colorant."
 )
 


### PR DESCRIPTION
The documentation currently states that`linewidth` represents the width of the axis lines, when in actual fact it describes the width of the grid lines.